### PR TITLE
Fixed bug in connection to rabbitMQ

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ var AMQP_RECONNECT_STRATEGY_LINEAR = "linear",
     AMQP_RECONNECT_BACKOFF_TIME = 1000,
     AMQP_EXCHANGE_TYPE_TOPIC = "topic",
     AMQP_EXCHANGE_DELIVERY_MODE_NON_PERSISTENT = 1,
-    RESPONSE_TIMEOUT = 3000,
-    CLIENT_ID = uuid.v4();
+    RESPONSE_TIMEOUT = 3000;
 
 module.exports = function(configuration){
+    var CLIENT_ID = uuid.v4();
 
     var sharedId = configuration["shared_id"] || "SHIBUYA";
 


### PR DESCRIPTION
Fixed bug in the scenario, when there are 2 require('shibuya') connections made from same host process.

Like in this sample code:

var shibuya = require('shibuya')({
    connection: {
    host: "127.0.0.1",
    port: 5672
    }
});

shibuya.register('core', {
    sum: function(o, cb){ cb('Error', 'OK'); }
});
setTimeout(function(){

// This can be a code in different js file, miles away, but in the same PROCESS
    var shibuya2 = require('shibuya')({  
            connection: {
            host: "127.0.0.1",
            port: 5672
        }
    });
    shibuya2.remoteCall('core', 'sum', {}, console.log.bind(console)); 

}, 1000);
